### PR TITLE
Remove some SBE 911plus assumptions from `parse_hdr` and `hex_to_dataset` 

### DIFF
--- a/src/odf/sbe/parsers.py
+++ b/src/odf/sbe/parsers.py
@@ -24,25 +24,28 @@ def parse_bl(bl):
     return log, resets
 
 
-def parse_hdr(hdr):
+def parse_hdr(hdr: str):
     """
     Parse the .hdr file's text into a dictionary.
     """
     comments = []
     hdr_dict = {}
     for line in hdr.splitlines():
-        if line.startswith("**"):
-            comments.append(line.strip("* "))
-            continue
-        if line == "*END*":
-            continue
         row = line.strip("* ")
-        if row.startswith("Sea-Bird SBE 9"):
+        if row == "END":
+            continue
+        if row.startswith("Sea-Bird SBE") and row.endswith("Data File:"):
+            hdr_dict["Data File"] = row.removeprefix("Sea-Bird SBE ").removesuffix(
+                " Data File:"
+            )
             continue
         if row.startswith("Software Version"):
             hdr_dict["Software Version"] = row.removeprefix("Software Version").strip()
             continue
-        key, value = row.split("=")
+        if "=" not in row:
+            comments.append(row)
+            continue
+        key, value = row.split("=", maxsplit=1)
         hdr_dict[key.strip()] = value.strip()
     hdr_dict["comments"] = "\n".join(comments)
     return hdr_dict


### PR DESCRIPTION
This PR addresses some assumptions we made when reading a hex file and parsing the headers of it. Alan got me a bunch more breakouts to test the r2r code with. I was immediately hit with two breaking assumptions we made:
* the number of bytes per scan will be in the header
* the header itself has any sort of structure we can assume

The additional breakouts I was provided with have data from non 911+ plus instruments that did not have any sort of scan length information in the header or xmlcon, though the sbe conreport exe could tell me how long the scans should be, I don't want to assume that information exists either and it puts a reliance on seabird software.

Bytes per scan fix: instead of assuming that this exists in the header and throwing if it does not, this first checks to see if this information is in there, and if not uses the most common scan length as the one to assume. I feel this is a safe assumption since, if it is not, the file is crazy corrupt and will be pretty useless. Even if the file is this corrupt, the attempt to read it will still work (i.e. not throw) but with undefined results. I suspect for non 911+ data files, the conversion to engineering units will also be invalid. This was not tested.

For the prase_header fix: The original implementation assumes that lines starting with `**` are the only comment lines and everything else is somewhat normal. The files was provided did not have `**` lines and some things still looked like comments. The seabird manual says "System UpLoad [sic] Time" and "System UTC" are basically free to do whatever with. I've change it to work as follows:
* Strip everything of leading `*`
* Omit the "END" line
* try to extract the model number into a "Data File" key
* assume everything without a `=` is a comment
* assume every line with a `=` is a key value pair and build a dictionary
* only split once on `=` just in case

This could still probably go wrong with actual comments that have `=` in them, but so long as this is just for parsing and getting information out of the file and not back into, should be ok. A future @DocOtak problem... (what have they ever done for me).

These fixes are critical for getting the r2r qa to run and with them, I was able to process and make the stoplight report for 160 profiles (7 breakouts) in about 100 seconds. This is without the SBE conreport creation... which is slower.